### PR TITLE
for redirect, use 307 (temporary) rather than 301 (permanent)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -240,9 +240,8 @@ function respondDownload(req, res, content, status) {
 	});
 }
 
-function respondRedirect(req, res, content) {
+function respondRedirect(req, res, content, status) {
 	content = content || null;
-	var status = 301;
 	// content needs to be redirect URL
 	res.writeHead(status, {
 		Location: content


### PR DESCRIPTION
when a session expires, I get redirected to the login page, but I can't get back to the page I want unless I clear browser cache.  
